### PR TITLE
feat: Mermaid import刷新 — mermaid.jsレイアウト + subgraphGroup対応 (#26, #27)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
+        "mermaid": "^11.13.0",
         "nanoid": "^5.1.6",
         "next": "16.1.6",
         "next-themes": "^0.4.6",
@@ -60,6 +61,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@antfu/ni": {
@@ -547,6 +561,51 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
+      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
+      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
+      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
+      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1597,6 +1656,23 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
@@ -2199,6 +2275,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
+      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -4898,10 +4983,100 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
@@ -4913,6 +5088,54 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -4922,10 +5145,76 @@
         "@types/d3-color": "*"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -4959,6 +5248,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -5011,6 +5306,13 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
@@ -5583,6 +5885,16 @@
         "win32"
       ]
     },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -5776,7 +6088,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -6427,6 +6738,32 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
+      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.1.2",
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/regexp-to-ast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "@chevrotain/utils": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^11.0.0"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -6611,6 +6948,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -6678,6 +7021,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
       }
     },
     "node_modules/cosmiconfig": {
@@ -6763,11 +7115,173 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -6794,11 +7308,113 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -6815,11 +7431,152 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -6866,6 +7623,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/damerau-levenshtein": {
@@ -6952,6 +7719,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7099,6 +7872,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7165,6 +7947,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
@@ -8706,6 +9497,12 @@
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8990,6 +9787,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ip-address": {
@@ -9809,6 +10615,31 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.44",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.44.tgz",
+      "integrity": "sha512-EkxoDTk8ufHqHlf9QxGwcxeLkWRR3iOuYfRpfORgYfqc8s13bgb+YtRY59NK5ZpRaCwq1kqA6a5lpX8C/eLphQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9819,6 +10650,11 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -9827,6 +10663,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/langium": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "~11.1.1",
+        "chevrotain-allstar": "~0.3.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -9848,6 +10701,12 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -10147,6 +11006,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -10257,6 +11122,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -10305,6 +11182,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
+      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.0.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
       }
     },
     "node_modules/micromatch": {
@@ -10402,6 +11308,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/ms": {
@@ -11085,7 +12003,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/parent-module": {
@@ -11163,6 +12080,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11201,7 +12124,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathval": {
@@ -11241,6 +12163,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -11870,6 +12819,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -11913,6 +12868,18 @@
         "@rollup/rollup-win32-x64-gnu": "4.59.0",
         "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
       }
     },
     "node_modules/router": {
@@ -11987,6 +12954,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -12046,7 +13019,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -12838,6 +13810,12 @@
         }
       }
     },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12933,7 +13911,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13097,6 +14074,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-morph": {
@@ -13312,6 +14298,12 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "license": "MIT"
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -13515,6 +14507,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
@@ -13756,6 +14761,55 @@
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
+    "mermaid": "^11.13.0",
     "nanoid": "^5.1.6",
     "next": "16.1.6",
     "next-themes": "^0.4.6",

--- a/specs/subgraph.md
+++ b/specs/subgraph.md
@@ -1,0 +1,632 @@
+# subgraph（視覚的グループ）仕様書
+
+## 概要
+
+Mermaidの `subgraph ... end` 構文を、「コンポーネント」とは別の概念である「視覚的グループ」として取り込み・表示・出力する機能。
+
+### コンポーネントとの違い
+
+| 観点 | subgraph（視覚的グループ） | コンポーネント（既存） |
+|---|---|---|
+| 目的 | 複数ノードの視覚的グループ化 | 再利用可能テンプレート |
+| 内部ノードの編集 | キャンバス上で直接編集可 | 専用編集モードが必要 |
+| Start/End | なし | あり（ロックされた Entry/Exit） |
+| 外部エッジ接続 | 子ノードに直接接続 | ブリッジエッジ経由 |
+| 折りたたみ | なし（将来課題） | あり |
+| React Flowの `parentId` | 使用する | 使用する |
+
+### スコープ（今回）
+
+- Mermaid import 時に subgraph を正しく取り込む（`parseMermaid` の変更）
+- subgraph ノードとその子ノードを React Flow の parentId 親子関係で表現
+- 外部エッジを子ノードに直接接続（リマップ）
+- subgraph のネスト対応
+- Mermaid 出力（generate.ts）で `subgraph ... end` として再出力
+- `.flowmaid` シリアライズ・デシリアライズ対応
+
+UIからの手動 subgraph 作成は今回のスコープ外。
+
+---
+
+## 実装方針
+
+### 方針A: subgraph を「グループノード」として React Flow の parentId 親子で表現（推奨）
+
+subgraph をコンテナノード（`type: "subgraphGroup"`）として作成し、子ノードに `parentId` を設定する。子ノードはキャンバス上で直接選択・ドラッグ・編集が可能。React Flow の標準的な子ノード機能をそのまま活用できる。
+
+**利点**
+- React Flow の親子関係（`parentId` + `extent: "parent"`）を使うため、グループ移動が標準挙動で動く
+- 子ノードをその場で編集可能（専用モード不要）
+- コンポーネントとは独立した概念として設計できる
+- Mermaid 出力が素直（subgraph ブロックに子ノードを列挙するだけ）
+
+**欠点**
+- 子ノードのサイズ・位置が subgraph 親に対して相対座標になる（パース時にオフセット計算が必要）
+- `extent: "parent"` を付けると子ノードが親の枠外に出せなくなる（グループリサイズ時に問題）
+
+### 方針B: subgraph を ComponentDefinition と同じデータ構造で表現
+
+既存の ComponentDefinition 型を再利用し、`entryNodeId: null / exitNodeId: null` でブリッジなし・直接接続モードの「subgraph型コンポーネント」として扱う。
+
+**利点**
+- 既存のシリアライズ・デシリアライズロジックをそのまま流用できる
+
+**欠点**
+- 「コンポーネント編集モードへの切替が必要」という制約も引き継いでしまう
+- 設計思想が違うものを同じ構造に無理やり収めることになる
+- `entryNodeId: null` の特例分岐が至るところに入り、既存コードの複雑性が増す
+
+### 方針C: 子ノードを独立したトップレベルノードとして持ち、subgraph は枠のみのオーバーレイで表現
+
+子ノードを親なしのトップレベルノードとして管理し、`subgraphGroupId` フィールドで所属グループを示す。subgraph 枠は別レイヤーの SVG オーバーレイで描画する。
+
+**利点**
+- 子ノードのドラッグ・編集が最も自由
+- `extent: "parent"` の制約がない
+
+**欠点**
+- グループ移動時に「グループ枠と全子ノードをまとめて動かす」カスタムロジックが必要
+- 子ノードの所属判定が複雑
+- React Flow の標準機能から外れる
+
+### 推奨案: 方針A
+
+React Flow の `parentId` 親子関係を使う方針A を採用する。理由：
+
+1. React Flow の標準的なグループノード機能（`parentId`）を使うことで、グループ全体の移動が自動的に動く
+2. 子ノードをキャンバス上でそのまま編集できる（subgraph の要件に最も合致）
+3. コンポーネントとのデータモデル上の独立性を保てる
+4. `extent: "parent"` は付けない方針とし、代わりに子ノードを親の範囲外にドラッグできるものとする（Mermaid subgraph の仕様に準じ、「グループは視覚的ヒントに過ぎない」という位置付け）
+
+---
+
+## データモデル
+
+### subgraphGroup ノード（親）
+
+```typescript
+// type: "subgraphGroup" の FlowNode
+{
+  id: "myGroup",
+  type: "subgraphGroup",
+  position: { x: 50, y: 100 },   // 子ノードのバウンディングボックスから算出
+  data: {
+    label: "認証処理",              // subgraph のラベル
+    shape: "rectangle",
+    isSubgraphGroup: true,          // subgraph 識別フラグ
+  },
+  style: { width: 400, height: 300 },  // 子ノード全体を包む枠サイズ
+  zIndex: -1,                      // 子ノードより背面に表示
+}
+```
+
+### 子ノード（既存 FlowNode に parentId を追加）
+
+`FlowNodeData` に新たに `subgraphParentId?: string` フィールドを追加する。
+
+```typescript
+// 既存の FlowNode に parentId + data.subgraphParentId を追加
+{
+  id: "A",
+  type: "rectangle",
+  parentId: "myGroup",              // React Flow 親子関係
+  position: { x: 20, y: 60 },      // 親の左上角からの相対座標
+  data: {
+    label: "処理A",
+    shape: "rectangle",
+    subgraphParentId: "myGroup",    // 識別用（componentParentId と区別するため専用フィールド）
+  },
+}
+```
+
+### FlowNodeData への追加フィールド
+
+```typescript
+// src/types/flow.ts の FlowNodeData に追加
+isSubgraphGroup?: boolean;    // このノードが subgraph グループ枠であることを示す
+subgraphParentId?: string;    // subgraph の子ノードであることを示す（親 ID を参照）
+```
+
+### .flowmaid レイアウトスキーマへの追加
+
+```typescript
+// src/lib/flowmaid/schema.ts の FlowmaidNodeLayout に追加
+isSubgraphGroup?: boolean;
+subgraphParentId?: string;
+```
+
+---
+
+## 変更・追加ファイル
+
+### 新規作成
+
+| ファイルパス | 役割 |
+|---|---|
+| `src/components/nodes/SubgraphGroupNode.tsx` | subgraph グループ枠のノードコンポーネント（ラベル表示、半透明背景、ドラッグ可能な枠） |
+| `src/lib/mermaid/renderLayout.ts` | mermaid.js レンダリングでSVGからノード・subgraphの位置・サイズを抽出 |
+
+### 変更
+
+| ファイルパス | 変更内容 |
+|---|---|
+| `src/types/flow.ts` | `FlowNodeData` に `isSubgraphGroup?: boolean`、`subgraphParentId?: string` を追加 |
+| `src/lib/mermaid/parse.ts` | subgraph → subgraphGroup ノード生成に変更、autoLayout呼び出し削除、mermaid.jsレイアウト結果を適用 |
+| `src/lib/mermaid/generate.ts` | `isSubgraphGroup: true` のノードを `subgraph ... end` として出力 |
+| `src/lib/flowmaid/schema.ts` | `FlowmaidNodeLayout` に `isSubgraphGroup`、`subgraphParentId` を追加 |
+| `src/lib/flowmaid/serialize.ts` | subgraph 子ノード（`subgraphParentId` あり）を通常ノードとしてシリアライズ（`componentParentId` の場合と異なりスキップしない） |
+| `src/lib/flowmaid/deserialize.ts` | `isSubgraphGroup: true` のノードを `type: "subgraphGroup"` で復元、子ノードに `parentId` を設定 |
+| `src/components/canvas/FlowCanvas.tsx` | `nodeTypes` に `subgraphGroup: SubgraphGroupNode` を追加 |
+| `src/components/layout/MermaidImportDialog.tsx` | parseMermaid呼び出し後にrenderMermaidLayoutを挟む（async化） |
+| `src/store/useFlowStore.ts` | `removeNodes` で subgraphGroup 削除時に子ノードも連動削除するロジックを追加 |
+| `package.json` | `mermaid` パッケージを依存に追加 |
+
+---
+
+## クラス設計
+
+### parse.ts の変更方針
+
+現在の `parseMermaid` 関数内（行 157〜376）では、subgraph を ComponentDefinition に変換する処理が行われている。この処理を以下のように変更する。
+
+#### 変更前の動作（現状）
+
+1. subgraph の子ノードを ComponentDefinition に登録
+2. 子ノードをトップレベルから除外してコンポーネントインスタンスノード（`type: "componentInstance"`）を生成
+3. 外部エッジをインスタンスノードにリマップ
+
+#### 変更後の動作
+
+1. subgraph の子ノードを収集し、バウンディングボックス（左上 minX/minY）を計算
+2. subgraphGroup ノードを生成（バウンディングボックス + パディング）
+3. 子ノードに `parentId` と `data.subgraphParentId` を設定、位置を相対座標に変換
+4. 外部エッジは**子ノードに直接接続**（リマップ不要、子ノード ID はそのまま保持）
+5. ComponentDefinition は生成しない
+
+#### ネスト subgraph の処理
+
+`subgraphStack` はスタック構造を維持。`subgraphStack.length > 1` の場合、内側の subgraph の子ノードを外側 subgraph の「子」ではなく内側 subgraph の「子」として独立して処理する。
+
+各 subgraph グループノードも子ノードとして外側 subgraph の `parentId` を持てる（React Flow の parentId チェーン）。
+
+#### subgraph ノード枠サイズの計算
+
+```
+SUBGRAPH_PADDING_X = 40  // 左右パディング
+SUBGRAPH_PADDING_Y_TOP = 40  // 上パディング（ラベル分）
+SUBGRAPH_PADDING_Y_BOTTOM = 20  // 下パディング
+
+subgraphWidth = (maxX - minX + childMaxWidth) + SUBGRAPH_PADDING_X * 2
+subgraphHeight = (maxY - minY + childMaxHeight) + SUBGRAPH_PADDING_Y_TOP + SUBGRAPH_PADDING_Y_BOTTOM
+
+subgraphPosition.x = minX - SUBGRAPH_PADDING_X
+subgraphPosition.y = minY - SUBGRAPH_PADDING_Y_TOP
+
+// 子ノードの相対座標
+childRelX = childAbsX - subgraphPosition.x
+childRelY = childAbsY - subgraphPosition.y
+```
+
+### generate.ts の変更方針
+
+```typescript
+// subgraphGroup ノードを subgraph ブロックとして出力
+if (node.data.isSubgraphGroup) {
+  lines.push(`    subgraph ${node.id}[${escapeMermaid(node.data.label)}]`);
+  // 子ノードを出力
+  for (const child of nodes.filter(n => n.data.subgraphParentId === node.id)) {
+    lines.push(nodeToMermaid(child));  // ID はそのまま（例: "A"）
+  }
+  // 子ノード間のエッジを出力
+  for (const edge of edges) {
+    if (childIds.has(edge.source) && childIds.has(edge.target) &&
+        subgraphChildBelongsTo(edge.source, node.id, nodes) &&
+        subgraphChildBelongsTo(edge.target, node.id, nodes)) {
+      lines.push(edgeToMermaid(edge));
+    }
+  }
+  lines.push(`    end`);
+  continue;
+}
+```
+
+外部エッジ（一方が subgraph 子ノード、他方が外部ノード）は通常のエッジとして出力する（子ノード ID をそのまま使用）。
+
+### SubgraphGroupNode コンポーネント
+
+```typescript
+// src/components/nodes/SubgraphGroupNode.tsx
+// - 半透明背景（fillColor が設定されていれば優先、デフォルトは --muted/30 程度）
+// - ラベルを左上に表示
+// - NodeResizer でリサイズ可能
+// - selectable: true（通常ノードと同様に選択・移動可）
+// - zIndex: -1 で常に子ノードより背面
+```
+
+### serialize.ts の変更
+
+```typescript
+// subgraph グループノード → 通常ノードとして出力（shape: "rectangle" + isSubgraphGroup: true）
+// subgraph 子ノード → componentParentId がある場合と「異なり」スキップしない
+//   （子ノードも個別に nodesLayout に含める）
+if (node.data.componentParentId) continue;  // 既存: componentの子はスキップ
+// subgraphParentId があっても continue しない（そのまま出力）
+
+// 追加フィールド
+if (node.data.isSubgraphGroup) entry.isSubgraphGroup = true;
+if (node.data.subgraphParentId) entry.subgraphParentId = node.data.subgraphParentId;
+```
+
+### deserialize.ts の変更
+
+```typescript
+// isSubgraphGroup: true のノード → type: "subgraphGroup" で復元
+const type = n.isSubgraphGroup
+  ? "subgraphGroup"
+  : (n.componentDefinitionId ? "componentInstance" : n.shape);
+
+// subgraphParentId があるノード → parentId を設定
+if (n.subgraphParentId) {
+  node.parentId = n.subgraphParentId;
+  node.data.subgraphParentId = n.subgraphParentId;
+}
+```
+
+### useFlowStore.ts の変更
+
+`removeNodes` アクション内で、削除対象に subgraphGroup ノードが含まれる場合、その子ノード（`subgraphParentId` が一致）も自動削除する。
+
+```typescript
+// subgraphGroup 削除時に子ノードも連動削除
+const subgraphGroupIds = new Set(ids.filter(id => {
+  const node = get().nodes.find(n => n.id === id);
+  return node?.data.isSubgraphGroup;
+}));
+const childIdsToRemove = get().nodes
+  .filter(n => n.data.subgraphParentId && subgraphGroupIds.has(n.data.subgraphParentId))
+  .map(n => n.id);
+const allIdsToRemove = [...ids, ...childIdsToRemove];
+```
+
+---
+
+## mermaid.js レンダリングによるサイズ・位置取得
+
+### 概要
+
+自前の `autoLayout` を廃止し、mermaid.js の公式レンダリングエンジンを使ってノードのサイズと位置を取得する。これにより Mermaid Live Editor とほぼ同じレイアウト結果が得られる。
+
+### 依存パッケージ
+
+```bash
+npm install mermaid
+```
+
+バンドルサイズが大きいため、dynamic import でインポート時のみロードする。
+
+### 処理フロー
+
+```
+1. MermaidImportDialog でユーザーが Mermaid テキストを入力
+2. parseMermaid() を呼び出し（テキスト解析のみ、レイアウトなし）
+   - ノード定義（ID, ラベル, 形状）を抽出
+   - エッジ定義（source, target, label）を抽出
+   - subgraph 構造を抽出
+   - direction を抽出
+3. renderMermaidLayout() を呼び出し（新規関数）
+   - 非表示の DOM 要素に mermaid.render() でSVGを生成
+   - SVG内の各ノード要素（.node クラス）から位置・サイズを抽出
+   - SVG内の subgraph 要素（.cluster クラス）から位置・サイズを抽出
+   - DOM 要素をクリーンアップ
+4. 抽出した位置・サイズを FlowNode に適用
+5. subgraph → subgraphGroup ノードに変換（子ノードを相対座標に）
+```
+
+### renderMermaidLayout 関数
+
+```typescript
+// src/lib/mermaid/renderLayout.ts（新規作成）
+
+interface MermaidNodeLayout {
+  id: string;
+  x: number;       // 中心X座標
+  y: number;       // 中心Y座標
+  width: number;
+  height: number;
+}
+
+interface MermaidSubgraphLayout {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface MermaidLayoutResult {
+  nodes: Map<string, MermaidNodeLayout>;
+  subgraphs: Map<string, MermaidSubgraphLayout>;
+}
+
+export async function renderMermaidLayout(
+  mermaidText: string
+): Promise<MermaidLayoutResult> {
+  // Dynamic import to avoid bundle size impact
+  const mermaid = await import("mermaid");
+  mermaid.default.initialize({
+    startOnLoad: false,
+    securityLevel: "loose",
+    flowchart: { htmlLabels: false },  // SVGラベルで正確なサイズ取得
+  });
+
+  // 非表示コンテナで render
+  const container = document.createElement("div");
+  container.style.position = "absolute";
+  container.style.left = "-9999px";
+  document.body.appendChild(container);
+
+  try {
+    const { svg } = await mermaid.default.render("mermaid-layout-tmp", mermaidText);
+    container.innerHTML = svg;
+    const svgEl = container.querySelector("svg")!;
+
+    // ノード位置・サイズ抽出
+    const nodes = new Map<string, MermaidNodeLayout>();
+    svgEl.querySelectorAll(".node").forEach((el) => {
+      const id = el.id?.replace(/^flowchart-/, "").replace(/-\d+$/, "");
+      if (!id) return;
+      const bbox = (el as SVGGraphicsElement).getBBox();
+      // transform を考慮して絶対座標を取得
+      const ctm = (el as SVGGraphicsElement).getCTM();
+      const svgCtm = svgEl.getCTM();
+      // ... 座標変換処理
+      nodes.set(id, { id, x, y, width: bbox.width, height: bbox.height });
+    });
+
+    // subgraph 位置・サイズ抽出
+    const subgraphs = new Map<string, MermaidSubgraphLayout>();
+    svgEl.querySelectorAll(".cluster").forEach((el) => {
+      const id = el.id?.replace(/^flowchart-/, "").replace(/-\d+$/, "");
+      if (!id) return;
+      const rect = el.querySelector("rect");
+      if (!rect) return;
+      // ... 座標・サイズ取得
+      subgraphs.set(id, { id, x, y, width, height });
+    });
+
+    return { nodes, subgraphs };
+  } finally {
+    document.body.removeChild(container);
+  }
+}
+```
+
+### SVG要素のID体系（mermaid.js内部）
+
+mermaid.js が生成するSVG内のノード要素は以下の命名規則:
+- ノード: `flowchart-{nodeId}-{数字}` というID、`.node` クラス
+- subgraph: `.cluster` クラス、内部に `rect` 要素
+- ノードIDの取得: `el.id` からプレフィックス・サフィックスを除去
+
+**注意**: mermaid.js のバージョンによりID体系が異なる可能性がある。実装時に実際のSVG出力を確認して調整すること。
+
+### 座標変換
+
+mermaid.js のSVG座標系はReact Flowのキャンバス座標系と異なる:
+- mermaid.js: ノードの中心座標を返す
+- React Flow: ノードの左上座標（top-left）を使用
+
+変換:
+```
+reactFlowX = mermaidCenterX - width / 2
+reactFlowY = mermaidCenterY - height / 2
+```
+
+### autoLayout の廃止
+
+`src/lib/mermaid/autoLayout.ts` は使用しなくなるが、フォールバック用に残しておく（mermaid.js のレンダリングが失敗した場合に使用）。
+
+`parseMermaid` から `autoLayout` の呼び出しを削除し、代わりに `renderMermaidLayout` の結果を使用する。
+
+---
+
+## Mermaid import フロー（変更後）
+
+```
+MermaidImportDialog
+  ↓
+1. ユーザーが Mermaid テキストを入力
+  ↓
+2. parseMermaid(text, edgeType) — テキスト解析のみ
+   a. ヘッダー解析（direction）
+   b. subgraphStack を使いつつ全行を走査
+   c. ノード定義・エッジ定義・subgraph構造を抽出
+   d. ※ autoLayout は呼ばない、位置・サイズは未定
+  ↓
+3. renderMermaidLayout(mermaidText) — mermaid.js でレイアウト
+   a. mermaid.render() でSVG生成
+   b. SVGからノード・subgraphの位置・サイズを抽出
+  ↓
+4. レイアウト結果を FlowNode に適用
+   a. 通常ノード: mermaid.js の座標 → React Flow 座標変換
+   b. subgraphGroup ノード: cluster の位置・サイズから生成
+   c. 子ノード: 絶対座標 → subgraphGroup に対する相対座標に変換
+   d. 外部エッジ: 子ノード ID をそのまま使用（リマップ不要）
+  ↓
+5. loadState({ nodes, edges, direction, nextIdCounter, componentDefinitions: [] })
+```
+
+---
+
+## .flowmaid シリアライズ
+
+### ノードの出力例
+
+```yaml
+nodes:
+  myGroup:
+    position: { x: 10, y: 50 }
+    size: { width: 400, height: 300 }
+    shape: rectangle
+    label: 認証処理
+    isSubgraphGroup: true
+  A:
+    position: { x: 20, y: 60 }    # subgraphGroup に対する相対座標
+    size: { width: 150, height: 50 }
+    shape: rectangle
+    label: 処理A
+    subgraphParentId: myGroup
+  B:
+    position: { x: 20, y: 160 }
+    size: { width: 100, height: 100 }
+    shape: diamond
+    label: 判断
+    subgraphParentId: myGroup
+```
+
+### エッジの出力例
+
+外部エッジは子ノード ID をそのまま使う（コンポーネントのようなリマップは不要）。
+
+```yaml
+edges:
+  A-B-bottom-source-top-target:
+    source: A
+    target: B
+  C-A-bottom-source-top-target:   # 外部ノード C → 子ノード A（直接接続）
+    source: C
+    target: A
+```
+
+---
+
+## Mermaid 出力（generate.ts）
+
+コンポーネント（`type: "componentInstance"`）と subgraph（`type: "subgraphGroup"` / `isSubgraphGroup: true`）は同じ `subgraph ... end` 構文で出力されるが、内部ロジックは独立して分岐する。
+
+```
+コンポーネント出力フロー（既存）:
+  node.type === "componentInstance" → def.nodes から内部ノードを subgraph 展開
+  外部エッジ → def.entryNodeId / exitNodeId にリマップして出力
+
+subgraph 出力フロー（新規）:
+  node.data.isSubgraphGroup === true → 子ノード（subgraphParentId 一致）を subgraph 展開
+  外部エッジ → 子ノード ID そのままで出力（リマップなし）
+```
+
+出力例:
+
+```
+flowchart TD
+    subgraph myGroup[認証処理]
+    A[処理A]
+    B{判断}
+    A --> B
+    end
+    C[外部ノード] --> A
+```
+
+---
+
+## 既存コンポーネントとの区別
+
+### parseMermaid における変更
+
+現在の `parseMermaid`（行 311〜376）は subgraph を ComponentDefinition + componentInstance に変換している。この変換を廃止し、subgraph はすべて subgraphGroup ノードとして扱う。
+
+変更後の parseMermaid は `componentDefinitions: []` を返す（Mermaid インポートからはコンポーネントを生成しない）。
+
+### 既存ユーザーへの影響
+
+- 既存の `.flowmaid` ファイルに `componentDefinitions` が含まれる場合はデシリアライズ時に従来通りコンポーネントインスタンスとして復元される（デシリアライズロジックは変更なし）
+- Mermaid テキストをインポートした場合のみ subgraphGroup として取り込まれるようになる（従来は componentInstance として取り込まれていたが、これは機能追加に伴う仕様変更）
+
+### generate.ts における区別
+
+```typescript
+// 出力時の分岐
+if (node.data.isSubgraphGroup) {
+  // subgraph グループとして出力（子ノードは直接参照）
+} else if (node.type === "componentInstance" && node.data.componentDefinitionId) {
+  // コンポーネントインスタンスとして出力（definition から内部ノードを展開）
+}
+```
+
+---
+
+## ネスト対応
+
+Mermaid の subgraph ネスト:
+
+```
+flowchart TD
+    subgraph outer[外部グループ]
+    subgraph inner[内部グループ]
+    A[処理A]
+    B[処理B]
+    end
+    C[処理C]
+    end
+```
+
+処理方針:
+
+1. `subgraphStack` を維持しながら走査
+2. inner の subgraphGroup ノードを生成し、`parentId: "outer"` を設定
+3. A, B には `parentId: "inner"` + `subgraphParentId: "inner"` を設定
+4. C には `parentId: "outer"` + `subgraphParentId: "outer"` を設定
+5. outer の枠サイズは inner グループ + C を含むバウンディングボックスから計算
+6. シリアライズ時はすべてのノードを個別に保持（ネスト関係は `subgraphParentId` フィールドで保持）
+
+---
+
+## 注意事項・制約
+
+### React Flow の parentId 挙動
+
+- `parentId` を持つノードは親ノードに対して相対座標で配置される
+- `extent: "parent"` を設定しない場合、子ノードは親の枠外にドラッグ可能（意図した仕様）
+- 親ノード（subgraphGroup）を移動すると子ノードも連動して移動する（React Flow 標準動作）
+- `zIndex` に `-1` を設定することで subgraphGroup 枠が子ノードの背面に表示される
+
+### undo/redo（zundo）
+
+- subgraphGroup と子ノードを同時に追加する操作は1アクションとしてコミットする必要がある
+- parseResult を `loadState` で一括ロードする Mermaid インポートフローでは問題ない
+- 将来的に UI から subgraphGroup を作成する際は `temporal.pause()` を使って複数操作を1コミットにまとめること
+
+### セレクタ・削除の連動
+
+- subgraphGroup ノードを Delete キーで削除した場合、子ノード（`subgraphParentId` 一致）も連動削除する（useFlowStore の `removeNodes` で対応）
+- 子ノードのみを削除した場合、subgraphGroup ノードは残る（空グループになる）
+
+### コンポーネント子ノードとの識別
+
+- `componentParentId` → コンポーネント子ノード（選択不可・ドラッグ不可）
+- `subgraphParentId` → subgraph 子ノード（選択可・ドラッグ可・編集可）
+- serialize.ts では `componentParentId` のノードはスキップするが `subgraphParentId` のノードはスキップしない
+
+### autoLayout の廃止
+
+mermaid.js レンダリングに切り替えるため、`autoLayout` はインポート時に使用しない。ファイルはフォールバック用に残すが、`parseMermaid` からの呼び出しは削除する。
+
+### テキスト型ノード
+
+`shape: "text"` のノードは Mermaid 出力から除外される（generate.ts の既存ロジック）。subgraphGroup の子ノードにテキストノードがある場合も同様に除外する。
+
+### BulkEdit モード
+
+BulkEdit テーブルでは `subgraphParentId` を持つ子ノードも通常ノードとして列挙する（コンポーネント子ノードとは異なる）。`isSubgraphGroup: true` の親ノード自体はラベル編集対象に含めてよい。
+
+### 差分比較（DiffComparison）
+
+差分比較モードでは subgraphGroup ノードも通常ノードとして比較対象に含まれる。`isSubgraphGroup: true` フィールドの差異も変更として検出する。
+
+---
+
+## 将来課題（今回スコープ外）
+
+- UI からの手動 subgraph 作成（複数ノード選択 → 右クリック → 「グループ化」）
+- subgraph の折りたたみ
+- subgraph のスタイル設定（背景色、枠線）
+- 子ノードを subgraph から取り出す操作

--- a/src/components/layout/MermaidImportDialog.tsx
+++ b/src/components/layout/MermaidImportDialog.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useLocale } from "@/lib/i18n/useLocale";
 import { parseMermaid } from "@/lib/mermaid/parse";
+import { renderMermaidLayout } from "@/lib/mermaid/renderLayout";
 import { useFlowStore } from "@/store/useFlowStore";
 import { toast } from "sonner";
 import type { EdgeType } from "@/types/flow";
@@ -50,9 +51,21 @@ export function MermaidImportDialog({
     localStorage.setItem(EDGE_TYPE_STORAGE_KEY, et);
   };
 
-  const doConvert = () => {
+  const [loading, setLoading] = useState(false);
+
+  const doConvert = async () => {
+    setLoading(true);
     try {
-      const result = parseMermaid(text, edgeType);
+      // Step 1: Try mermaid.js layout first for accurate positioning
+      let layout: Awaited<ReturnType<typeof renderMermaidLayout>> | undefined;
+      try {
+        layout = await renderMermaidLayout(text);
+      } catch (e) {
+        console.warn("mermaid.js layout failed, falling back to autoLayout", e);
+      }
+
+      // Step 2: Parse with layout result
+      const result = parseMermaid(text, edgeType, layout);
       loadState(result);
       toast.success(t("mermaidImportSuccess"));
       setText("");
@@ -60,14 +73,16 @@ export function MermaidImportDialog({
       onSuccess?.();
     } catch {
       toast.error(t("mermaidParseFailed"));
+    } finally {
+      setLoading(false);
     }
   };
 
-  const handleConvert = () => {
+  const handleConvert = async () => {
     if (hasContent) {
       if (!window.confirm(t("mermaidOverwriteConfirm"))) return;
     }
-    doConvert();
+    await doConvert();
   };
 
   return (
@@ -102,8 +117,8 @@ export function MermaidImportDialog({
           placeholder={"graph TD\n    A[Start] --> B{Condition}\n    B -->|Yes| C[End]"}
         />
         <DialogFooter>
-          <Button onClick={handleConvert} disabled={!text.trim()}>
-            {t("convert")}
+          <Button onClick={handleConvert} disabled={!text.trim() || loading}>
+            {loading ? "..." : t("convert")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/nodes/SubgraphGroupNode.tsx
+++ b/src/components/nodes/SubgraphGroupNode.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { memo, useState } from "react";
+import { NodeResizer, Position, type NodeProps } from "@xyflow/react";
+import type { FlowNodeData } from "@/types/flow";
+import { ConnectHandle } from "./ConnectHandle";
+
+const HANDLE_POSITIONS = [Position.Top, Position.Right, Position.Bottom, Position.Left];
+
+type SubgraphGroupNodeProps = NodeProps & {
+  data: FlowNodeData;
+};
+
+export const SubgraphGroupNode = memo(function SubgraphGroupNode({
+  id,
+  data,
+  selected,
+}: SubgraphGroupNodeProps) {
+  const label = data.label || id;
+  const [hovered, setHovered] = useState(false);
+  const visible = hovered;
+
+  return (
+    <div
+      className="relative w-full h-full rounded-lg border-2 border-dashed"
+      style={{
+        borderColor: selected
+          ? "var(--color-primary)"
+          : "var(--color-muted-foreground)",
+        backgroundColor: "color-mix(in srgb, var(--color-muted) 30%, transparent)",
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <NodeResizer
+        isVisible={!!selected}
+        minWidth={100}
+        minHeight={60}
+        lineStyle={{ borderColor: "var(--color-primary)" }}
+        handleStyle={{ backgroundColor: "var(--color-primary)" }}
+      />
+      {HANDLE_POSITIONS.map((pos) => (
+        <ConnectHandle key={`target-${pos}`} pos={pos} type="target" visible={visible} nodeId={id} />
+      ))}
+      {HANDLE_POSITIONS.map((pos) => (
+        <ConnectHandle key={`source-${pos}`} pos={pos} type="source" visible={visible} nodeId={id} />
+      ))}
+      <div
+        className="absolute top-1 left-2 text-xs font-semibold select-none pointer-events-none"
+        style={{
+          color: "var(--color-foreground)",
+          opacity: 1,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  );
+});

--- a/src/components/nodes/nodeTypes.ts
+++ b/src/components/nodes/nodeTypes.ts
@@ -13,6 +13,7 @@ import { ManualInputNode } from "./ManualInputNode";
 import { InternalStorageNode } from "./InternalStorageNode";
 import { DisplayNode } from "./DisplayNode";
 import { ComponentInstanceNode } from "./ComponentInstanceNode";
+import { SubgraphGroupNode } from "./SubgraphGroupNode";
 export const nodeTypes = {
   rectangle: RectangleNode,
   diamond: DiamondNode,
@@ -30,4 +31,5 @@ export const nodeTypes = {
   display: DisplayNode,
   text: RectangleNode,
   componentInstance: ComponentInstanceNode,
+  subgraphGroup: SubgraphGroupNode,
 };

--- a/src/lib/flowmaid/__tests__/serialize.test.ts
+++ b/src/lib/flowmaid/__tests__/serialize.test.ts
@@ -42,7 +42,7 @@ describe("serialize", () => {
 
     expect(output).toContain("--- mermaid ---");
     expect(output).toContain("--- layout ---");
-    expect(output).toContain("graph TD");
+    expect(output).toContain("flowchart TD");
     expect(output).toContain("A[Start]");
     expect(output).toContain("B{Check}");
     expect(output).toContain("A -->|next| B");

--- a/src/lib/flowmaid/__tests__/subgraph-serialize.test.ts
+++ b/src/lib/flowmaid/__tests__/subgraph-serialize.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import { serialize } from "../serialize";
+import { deserialize } from "../deserialize";
+import type { FlowNode, FlowEdge } from "@/store/types";
+
+describe("subgraphGroup serialize/deserialize round-trip", () => {
+  const nodes: FlowNode[] = [
+    {
+      id: "sg1",
+      type: "subgraphGroup",
+      position: { x: 10, y: 50 },
+      data: { label: "MyGroup", shape: "rectangle", isSubgraphGroup: true },
+      style: { width: 400, height: 300 },
+      zIndex: -1,
+    },
+    {
+      id: "A",
+      type: "rectangle",
+      position: { x: 20, y: 60 },
+      parentId: "sg1",
+      data: { label: "NodeA", shape: "rectangle", subgraphParentId: "sg1" },
+      style: { width: 150, height: 50 },
+    },
+    {
+      id: "B",
+      type: "diamond",
+      position: { x: 20, y: 160 },
+      parentId: "sg1",
+      data: { label: "NodeB", shape: "diamond", subgraphParentId: "sg1" },
+      style: { width: 100, height: 100 },
+    },
+    {
+      id: "C",
+      type: "rectangle",
+      position: { x: 500, y: 200 },
+      data: { label: "External", shape: "rectangle" },
+      style: { width: 150, height: 50 },
+    },
+  ];
+
+  const edges: FlowEdge[] = [
+    {
+      id: "A-B-bottom-source-top-target",
+      source: "A",
+      target: "B",
+      type: "labeled",
+      sourceHandle: "bottom-source",
+      targetHandle: "top-target",
+      data: { label: "", edgeType: "bezier", markerEnd: "arrowclosed" },
+    },
+    {
+      id: "B-C-right-source-left-target",
+      source: "B",
+      target: "C",
+      type: "labeled",
+      sourceHandle: "right-source",
+      targetHandle: "left-target",
+      data: { label: "go", edgeType: "bezier", markerEnd: "arrowclosed" },
+    },
+  ];
+
+  it("serializes subgraphGroup fields", () => {
+    const output = serialize(nodes, edges, "TD");
+    expect(output).toContain("isSubgraphGroup: true");
+    expect(output).toContain("subgraphParentId: sg1");
+    // Both child nodes should be present (not skipped)
+    expect(output).toContain("A:");
+    expect(output).toContain("B:");
+  });
+
+  it("deserializes subgraphGroup correctly", () => {
+    const output = serialize(nodes, edges, "TD");
+    const result = deserialize(output);
+
+    // SubgraphGroup node
+    const sgNode = result.nodes.find((n) => n.id === "sg1");
+    expect(sgNode).toBeDefined();
+    expect(sgNode!.type).toBe("subgraphGroup");
+    expect(sgNode!.data.isSubgraphGroup).toBe(true);
+
+    // Child nodes with parentId
+    const nodeA = result.nodes.find((n) => n.id === "A");
+    expect(nodeA).toBeDefined();
+    expect(nodeA!.parentId).toBe("sg1");
+    expect(nodeA!.data.subgraphParentId).toBe("sg1");
+
+    const nodeB = result.nodes.find((n) => n.id === "B");
+    expect(nodeB).toBeDefined();
+    expect(nodeB!.parentId).toBe("sg1");
+
+    // External node
+    const nodeC = result.nodes.find((n) => n.id === "C");
+    expect(nodeC).toBeDefined();
+    expect(nodeC!.parentId).toBeUndefined();
+
+    // All edges preserved
+    expect(result.edges).toHaveLength(2);
+  });
+
+  it("round-trips positions correctly", () => {
+    const output = serialize(nodes, edges, "TD");
+    const result = deserialize(output);
+
+    const sgNode = result.nodes.find((n) => n.id === "sg1");
+    expect(sgNode!.position).toEqual({ x: 10, y: 50 });
+
+    const nodeA = result.nodes.find((n) => n.id === "A");
+    expect(nodeA!.position).toEqual({ x: 20, y: 60 });
+  });
+});

--- a/src/lib/flowmaid/deserialize.ts
+++ b/src/lib/flowmaid/deserialize.ts
@@ -44,9 +44,12 @@ export function deserialize(content: string): DeserializeResult {
 
   for (const [id, n] of Object.entries(layout.nodes)) {
     const isComponentInstance = !!n.componentDefinitionId;
+    const type = n.isSubgraphGroup
+      ? "subgraphGroup"
+      : (isComponentInstance ? "componentInstance" : n.shape);
     const node: FlowNode = {
       id,
-      type: isComponentInstance ? "componentInstance" : n.shape,
+      type,
       position: n.position,
       data: {
         label: n.label,
@@ -82,6 +85,11 @@ export function deserialize(content: string): DeserializeResult {
     if (n.bold) node.data.bold = n.bold;
     if (n.italic) node.data.italic = n.italic;
     if (n.underline) node.data.underline = n.underline;
+    if (n.isSubgraphGroup) node.data.isSubgraphGroup = true;
+    if (n.subgraphParentId) {
+      node.parentId = n.subgraphParentId;
+      node.data.subgraphParentId = n.subgraphParentId;
+    }
 
     nodes.push(node);
 
@@ -169,6 +177,15 @@ export function deserialize(content: string): DeserializeResult {
       bridgeEdges.push(b);
     }
   }
+
+  // Sort nodes so parents come before children (React Flow requires this for parentId)
+  allNodes.sort((a, b) => {
+    if (!a.parentId && b.parentId) return -1;
+    if (a.parentId && !b.parentId) return 1;
+    if (b.parentId === a.id) return -1;
+    if (a.parentId === b.id) return 1;
+    return 0;
+  });
 
   return {
     nodes: allNodes,

--- a/src/lib/flowmaid/schema.ts
+++ b/src/lib/flowmaid/schema.ts
@@ -29,6 +29,9 @@ export interface FlowmaidNodeLayout {
   componentSyncVersion?: number;
   collapsed?: boolean;
   expandedSize?: { width: number; height: number };
+  // Subgraph (visual group) fields
+  isSubgraphGroup?: boolean;
+  subgraphParentId?: string;
 }
 
 export interface FlowmaidEdgeLayout {

--- a/src/lib/flowmaid/serialize.ts
+++ b/src/lib/flowmaid/serialize.ts
@@ -28,6 +28,7 @@ export function serialize(
   const nodesLayout: Record<string, FlowmaidNodeLayout> = {};
   for (const node of nodes) {
     // Skip component child nodes (they're regenerated from definition)
+    // Note: subgraphGroup child nodes (subgraphParentId) are NOT skipped — they're serialized individually
     if (node.data.componentParentId) continue;
     const styleW = (node.style as Record<string, unknown>)?.width as number | undefined;
     const styleH = (node.style as Record<string, unknown>)?.height as number | undefined;
@@ -63,6 +64,8 @@ export function serialize(
     if (node.data.componentSyncVersion !== undefined) entry.componentSyncVersion = node.data.componentSyncVersion as number;
     if (node.data.collapsed) entry.collapsed = true;
     if (node.data.expandedSize) entry.expandedSize = node.data.expandedSize as { width: number; height: number };
+    if (node.data.isSubgraphGroup) entry.isSubgraphGroup = true;
+    if (node.data.subgraphParentId) entry.subgraphParentId = node.data.subgraphParentId as string;
 
     nodesLayout[node.id] = entry;
   }

--- a/src/lib/mermaid/__tests__/component.test.ts
+++ b/src/lib/mermaid/__tests__/component.test.ts
@@ -111,7 +111,7 @@ describe("generateMermaid with component instances", () => {
 });
 
 describe("parseMermaid with subgraph", () => {
-  it("parses subgraph into definitions and instances", () => {
+  it("parses subgraph into subgraphGroup nodes", () => {
     const input = `graph TD
     subgraph Auth[Authentication]
     A[Start] --> B[Login]
@@ -121,19 +121,34 @@ describe("parseMermaid with subgraph", () => {
     C --> D`;
 
     const result = parseMermaid(input);
-    expect(result.componentDefinitions).toBeDefined();
-    expect(result.componentDefinitions!.length).toBe(1);
-    expect(result.componentDefinitions![0].name).toBe("Authentication");
-    expect(result.componentDefinitions![0].nodes).toHaveLength(3);
-    expect(result.componentDefinitions![0].edges).toHaveLength(2);
 
-    // Should have instance node + dashboard node
-    const instanceNode = result.nodes.find((n) => n.type === "componentInstance");
-    expect(instanceNode).toBeDefined();
-    expect(instanceNode!.data.componentInstanceName).toBe("Authentication");
+    // Should have subgraphGroup node
+    const sgNode = result.nodes.find((n) => n.type === "subgraphGroup");
+    expect(sgNode).toBeDefined();
+    expect(sgNode!.id).toBe("Auth");
+    expect(sgNode!.data.label).toBe("Authentication");
+    expect(sgNode!.data.isSubgraphGroup).toBe(true);
 
+    // Child nodes should have parentId and subgraphParentId
+    const childA = result.nodes.find((n) => n.id === "A");
+    expect(childA).toBeDefined();
+    expect(childA!.parentId).toBe("Auth");
+    expect(childA!.data.subgraphParentId).toBe("Auth");
+
+    const childB = result.nodes.find((n) => n.id === "B");
+    expect(childB!.parentId).toBe("Auth");
+
+    const childC = result.nodes.find((n) => n.id === "C");
+    expect(childC!.parentId).toBe("Auth");
+
+    // Dashboard should be a top-level node
     const dashNode = result.nodes.find((n) => n.id === "D");
     expect(dashNode).toBeDefined();
+    expect(dashNode!.parentId).toBeUndefined();
+
+    // Edges should reference child node IDs directly (no remapping)
+    const edgeCD = result.edges.find((e) => e.source === "C" && e.target === "D");
+    expect(edgeCD).toBeDefined();
   });
 
   it("parses subgraph without bracket label", () => {
@@ -143,7 +158,92 @@ describe("parseMermaid with subgraph", () => {
     end`;
 
     const result = parseMermaid(input);
-    expect(result.componentDefinitions).toBeDefined();
-    expect(result.componentDefinitions![0].name).toBe("Auth");
+    const sgNode = result.nodes.find((n) => n.type === "subgraphGroup");
+    expect(sgNode).toBeDefined();
+    expect(sgNode!.data.label).toBe("Auth");
+  });
+
+  it("parses nested subgraphs", () => {
+    const input = `graph TD
+    subgraph outer[Outer]
+    subgraph inner[Inner]
+    A[NodeA]
+    B[NodeB]
+    end
+    C[NodeC]
+    end`;
+
+    const result = parseMermaid(input);
+
+    const outerSg = result.nodes.find((n) => n.id === "outer");
+    expect(outerSg).toBeDefined();
+    expect(outerSg!.data.isSubgraphGroup).toBe(true);
+    expect(outerSg!.parentId).toBeUndefined();
+
+    const innerSg = result.nodes.find((n) => n.id === "inner");
+    expect(innerSg).toBeDefined();
+    expect(innerSg!.data.isSubgraphGroup).toBe(true);
+    expect(innerSg!.parentId).toBe("outer");
+    expect(innerSg!.data.subgraphParentId).toBe("outer");
+
+    const nodeA = result.nodes.find((n) => n.id === "A");
+    expect(nodeA!.parentId).toBe("inner");
+    expect(nodeA!.data.subgraphParentId).toBe("inner");
+
+    const nodeC = result.nodes.find((n) => n.id === "C");
+    expect(nodeC!.parentId).toBe("outer");
+    expect(nodeC!.data.subgraphParentId).toBe("outer");
+  });
+
+  it("handles 3-level nested subgraphs with edges to subgraph IDs", () => {
+    const input = `flowchart TB
+    subgraph WSL[WSL2]
+        PodmanCLI[CLI]
+        subgraph Container[Container]
+            App[App]
+            subgraph Agents[Agents]
+                A1[Agent1]
+                A2[Agent2]
+            end
+        end
+    end
+    subgraph External[External]
+        LLM[LLM]
+    end
+    D[Dashboard] --> WSL
+    PodmanCLI -->|manage| Container
+    App --> Agents
+    Agents -->|call| LLM`;
+
+    const result = parseMermaid(input);
+
+    // All subgraphs should be subgraphGroup nodes, not regular nodes
+    for (const sgId of ["WSL", "Container", "Agents", "External"]) {
+      const sg = result.nodes.find((n) => n.id === sgId);
+      expect(sg, `${sgId} should exist`).toBeDefined();
+      expect(sg!.type, `${sgId} should be subgraphGroup`).toBe("subgraphGroup");
+      expect(sg!.data.isSubgraphGroup, `${sgId} should have isSubgraphGroup`).toBe(true);
+      // No duplicate regular node
+      const all = result.nodes.filter((n) => n.id === sgId);
+      expect(all, `${sgId} should have exactly 1 node`).toHaveLength(1);
+    }
+
+    // Verify nesting hierarchy
+    expect(result.nodes.find((n) => n.id === "Container")!.parentId).toBe("WSL");
+    expect(result.nodes.find((n) => n.id === "Agents")!.parentId).toBe("Container");
+
+    // Verify child assignments
+    expect(result.nodes.find((n) => n.id === "PodmanCLI")!.data.subgraphParentId).toBe("WSL");
+    expect(result.nodes.find((n) => n.id === "App")!.data.subgraphParentId).toBe("Container");
+    expect(result.nodes.find((n) => n.id === "A1")!.data.subgraphParentId).toBe("Agents");
+
+    // Edges to subgraph IDs should work
+    const edgeDtoWSL = result.edges.find((e) => e.target === "WSL");
+    expect(edgeDtoWSL).toBeDefined();
+    const edgeToAgents = result.edges.find((e) => e.source === "App" && e.target === "Agents");
+    expect(edgeToAgents).toBeDefined();
+
+    // WSL subgraph label
+    expect(result.nodes.find((n) => n.id === "WSL")!.data.label).toBe("WSL2");
   });
 });

--- a/src/lib/mermaid/__tests__/generate.test.ts
+++ b/src/lib/mermaid/__tests__/generate.test.ts
@@ -102,12 +102,101 @@ describe("generateMermaid", () => {
 
     const result = generateMermaid(nodes, edges, "TD");
     expect(result).toBe(
-      `graph TD\n    A[Start]\n    B{Decision}\n    C((End))\n    A --> B\n    B -->|Yes| C`
+      `flowchart TD\n    A[Start]\n    B{Decision}\n    C((End))\n    A --> B\n    B -->|Yes| C`
     );
   });
 
   it("uses LR direction", () => {
     const result = generateMermaid([], [], "LR");
-    expect(result).toBe("graph LR");
+    expect(result).toBe("flowchart LR");
+  });
+
+  it("generates subgraph for subgraphGroup nodes", () => {
+    const nodes: FlowNode[] = [
+      {
+        id: "sg1",
+        type: "subgraphGroup",
+        position: { x: 0, y: 0 },
+        data: { label: "MyGroup", shape: "rectangle", isSubgraphGroup: true },
+      },
+      {
+        id: "A",
+        type: "rectangle",
+        parentId: "sg1",
+        position: { x: 20, y: 60 },
+        data: { label: "NodeA", shape: "rectangle", subgraphParentId: "sg1" },
+      },
+      {
+        id: "B",
+        type: "diamond",
+        parentId: "sg1",
+        position: { x: 20, y: 160 },
+        data: { label: "NodeB", shape: "diamond", subgraphParentId: "sg1" },
+      },
+      {
+        id: "C",
+        type: "rectangle",
+        position: { x: 500, y: 200 },
+        data: { label: "External", shape: "rectangle" },
+      },
+    ];
+    const edges: FlowEdge[] = [
+      makeEdge("A", "B"),
+      makeEdge("B", "C", "go"),
+    ];
+
+    const result = generateMermaid(nodes, edges, "TD");
+    expect(result).toContain("subgraph sg1[MyGroup]");
+    expect(result).toContain("A[NodeA]");
+    expect(result).toContain("B{NodeB}");
+    expect(result).toContain("A --> B");
+    expect(result).toContain("end");
+    // External edge should be outside the subgraph block
+    expect(result).toContain("B -->|go| C");
+    // External node should be outside the subgraph block
+    expect(result).toContain("C[External]");
+  });
+
+  it("outputs edges to nested subgraphGroup nodes within parent subgraph", () => {
+    const nodes: FlowNode[] = [
+      {
+        id: "WSL",
+        type: "subgraphGroup",
+        position: { x: 0, y: 0 },
+        data: { label: "WSL2", shape: "rectangle", isSubgraphGroup: true },
+      },
+      {
+        id: "CLI",
+        type: "rectangle",
+        parentId: "WSL",
+        position: { x: 20, y: 60 },
+        data: { label: "CLI", shape: "rectangle", subgraphParentId: "WSL" },
+      },
+      {
+        id: "Container",
+        type: "subgraphGroup",
+        parentId: "WSL",
+        position: { x: 20, y: 160 },
+        data: { label: "Container", shape: "rectangle", isSubgraphGroup: true, subgraphParentId: "WSL" },
+      },
+      {
+        id: "App",
+        type: "rectangle",
+        parentId: "Container",
+        position: { x: 10, y: 30 },
+        data: { label: "App", shape: "rectangle", subgraphParentId: "Container" },
+      },
+    ];
+    const edges: FlowEdge[] = [
+      makeEdge("CLI", "Container", "manage"),
+      makeEdge("App", "WSL"),
+    ];
+
+    const result = generateMermaid(nodes, edges, "TD");
+    // Edge from regular node to nested subgraphGroup should be inside WSL's subgraph block
+    expect(result).toContain("CLI -->|manage| Container");
+    // Edge from deeply nested node to top-level subgraph should be at top level
+    // (App is subgraphChild, WSL is not a subgraphChild → not both in subgraphChildIds → top-level)
+    expect(result).toContain("App --> WSL");
   });
 });

--- a/src/lib/mermaid/__tests__/parse.test.ts
+++ b/src/lib/mermaid/__tests__/parse.test.ts
@@ -169,11 +169,90 @@ describe("round-trip: generateMermaid → parseMermaid", () => {
     // Re-generate and verify structure matches
     const regenerated = generateMermaid(parsed.nodes, parsed.edges, parsed.direction);
     const lines = regenerated.split("\n");
-    expect(lines[0]).toBe("graph TD");
+    expect(lines[0]).toBe("flowchart TD");
     expect(lines).toContainEqual("    A[Start]");
     expect(lines).toContainEqual("    B{Decision}");
     expect(lines).toContainEqual("    C((End))");
     expect(lines).toContainEqual("    A --> B");
     expect(lines).toContainEqual("    B -->|Yes| C");
+  });
+});
+
+describe("parseMermaid - extended features", () => {
+  it("parses dotted arrows (-.->)", () => {
+    const result = parseMermaid("graph TD\nA[Start] -.-> B[End]");
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].source).toBe("A");
+    expect(result.edges[0].target).toBe("B");
+  });
+
+  it("parses dotted arrows with labels", () => {
+    const result = parseMermaid("graph TD\nA[Start] -.->|label| B[End]");
+    expect(result.edges).toHaveLength(1);
+    expect(result.edges[0].data?.label).toBe("label");
+  });
+
+  it("strips double quotes from labels", () => {
+    const result = parseMermaid('graph TD\nA["Quoted Label"]');
+    expect(result.nodes[0].data.label).toBe("Quoted Label");
+  });
+
+  it("converts <br/> to newline in labels", () => {
+    const result = parseMermaid('graph TD\nA["Line1<br/>Line2"]');
+    expect(result.nodes[0].data.label).toBe("Line1\nLine2");
+  });
+
+  it("handles subgraph ID used as edge endpoint", () => {
+    const input = `graph TD
+    subgraph sg1[Group]
+    A[NodeA]
+    end
+    B[NodeB]
+    B --> sg1`;
+    const result = parseMermaid(input);
+    // sg1 should be a subgraphGroup, not a regular node
+    const sgNode = result.nodes.find((n) => n.id === "sg1");
+    expect(sgNode).toBeDefined();
+    expect(sgNode!.type).toBe("subgraphGroup");
+    // There should NOT be a duplicate rectangle node for sg1
+    const sg1Nodes = result.nodes.filter((n) => n.id === "sg1");
+    expect(sg1Nodes).toHaveLength(1);
+    // Edge should reference the subgraph ID
+    const edge = result.edges.find((e) => e.target === "sg1");
+    expect(edge).toBeDefined();
+  });
+
+  it("parses complex nested Mermaid with mixed features", () => {
+    const input = `flowchart TB
+    subgraph outer["Outer Group"]
+        A["Node A<br/>line2"]
+        subgraph inner["Inner Group"]
+            B["Node B"]
+            C["Node C"]
+            B --> C
+        end
+    end
+    D[External] --> A
+    D -.->|dotted| inner`;
+    const result = parseMermaid(input);
+
+    // Verify subgraph structure
+    const outerSg = result.nodes.find((n) => n.id === "outer");
+    expect(outerSg).toBeDefined();
+    expect(outerSg!.data.isSubgraphGroup).toBe(true);
+    expect(outerSg!.data.label).toBe("Outer Group");
+
+    const innerSg = result.nodes.find((n) => n.id === "inner");
+    expect(innerSg).toBeDefined();
+    expect(innerSg!.parentId).toBe("outer");
+
+    // Verify labels
+    const nodeA = result.nodes.find((n) => n.id === "A");
+    expect(nodeA!.data.label).toBe("Node A\nline2");
+
+    // Verify dotted edge was parsed
+    const dottedEdge = result.edges.find((e) => e.source === "D" && e.target === "inner");
+    expect(dottedEdge).toBeDefined();
+    expect(dottedEdge!.data?.label).toBe("dotted");
   });
 });

--- a/src/lib/mermaid/generate.ts
+++ b/src/lib/mermaid/generate.ts
@@ -5,6 +5,47 @@ import { escapeMermaid } from "./nodeToMermaid";
 import { edgeToMermaid } from "./edgeToMermaid";
 
 /**
+ * Recursively emit a subgraph block for a subgraphGroup node.
+ * Handles arbitrary nesting depth. Edges are output at the level where
+ * both source and target are direct children (not deeper descendants).
+ */
+function emitSubgraphBlock(
+  sgId: string,
+  sgLabel: string,
+  nodes: FlowNode[],
+  edges: FlowEdge[],
+  lines: string[],
+): void {
+  lines.push(`    subgraph ${sgId}[${escapeMermaid(sgLabel)}]`);
+
+  const children = nodes.filter((n) => n.data.subgraphParentId === sgId);
+  // All direct children IDs (both regular nodes and nested subgraphGroups)
+  const allDirectChildIds = new Set<string>();
+
+  for (const child of children) {
+    if (child.data.shape === "text") continue;
+    allDirectChildIds.add(child.id);
+    if (child.data.isSubgraphGroup) {
+      // Recurse into nested subgraph
+      emitSubgraphBlock(child.id, child.data.label, nodes, edges, lines);
+    } else {
+      lines.push(nodeToMermaid(child));
+    }
+  }
+
+  // Output edges where both endpoints are direct children of this group
+  // (includes edges between regular nodes and nested subgraphGroup nodes)
+  for (const edge of edges) {
+    if (edge.data?.isBridgeEdge) continue;
+    if (allDirectChildIds.has(edge.source) && allDirectChildIds.has(edge.target)) {
+      lines.push(edgeToMermaid(edge));
+    }
+  }
+
+  lines.push(`    end`);
+}
+
+/**
  * Generate complete Mermaid flowchart syntax from nodes, edges, and direction
  */
 export function generateMermaid(
@@ -13,7 +54,7 @@ export function generateMermaid(
   direction: FlowDirection,
   definitions?: ComponentDefinition[]
 ): string {
-  const lines: string[] = [`graph ${direction}`];
+  const lines: string[] = [`flowchart ${direction}`];
 
   // Build map of component instance IDs to their child nodes
   const instanceChildMap = new Map<string, FlowNode[]>();
@@ -27,10 +68,26 @@ export function generateMermaid(
     }
   }
 
+  // Build set of subgraph child node IDs
+  const subgraphChildIds = new Set<string>();
+  for (const node of nodes) {
+    if (node.data.subgraphParentId) {
+      subgraphChildIds.add(node.id);
+    }
+  }
+
   for (const node of nodes) {
     if (node.data.shape === "text") continue;
     // Skip component children (they're handled within their parent's subgraph)
     if (node.data.componentParentId) continue;
+    // Skip subgraph children (they're handled within their parent's subgraph block)
+    if (node.data.subgraphParentId) continue;
+
+    // Subgraph group: output as subgraph block with child nodes (recursive for nesting)
+    if (node.data.isSubgraphGroup) {
+      emitSubgraphBlock(node.id, node.data.label, nodes, edges, lines);
+      continue;
+    }
 
     // Component instance: expand as subgraph using definition (including Start/End)
     if (node.type === "componentInstance" && node.data.componentDefinitionId) {
@@ -128,8 +185,17 @@ export function generateMermaid(
   for (const edge of edges) {
     // Skip bridge edges
     if (edge.data?.isBridgeEdge) continue;
-    // Skip internal edges (already handled in subgraph)
+    // Skip internal edges (already handled in component subgraph)
     if (childNodeIds.has(edge.source) && childNodeIds.has(edge.target)) continue;
+    // Skip edges between subgraph children that share the same direct parent
+    // (already handled in their subgraph block). Cross-subgraph edges are output here.
+    if (subgraphChildIds.has(edge.source) && subgraphChildIds.has(edge.target)) {
+      const srcNode = nodes.find((n) => n.id === edge.source);
+      const tgtNode = nodes.find((n) => n.id === edge.target);
+      const srcParent = srcNode?.data.subgraphParentId as string | undefined;
+      const tgtParent = tgtNode?.data.subgraphParentId as string | undefined;
+      if (srcParent && tgtParent && srcParent === tgtParent) continue;
+    }
 
     // For edges connected to component instances, remap to entry/exit child nodes
     if (definitions) {

--- a/src/lib/mermaid/parse.ts
+++ b/src/lib/mermaid/parse.ts
@@ -1,18 +1,20 @@
 import type { FlowNode, FlowEdge } from "@/store/types";
-import type { FlowDirection, NodeShape, ComponentDefinition, ComponentInternalNode, ComponentInternalEdge } from "@/types/flow";
+import type { FlowDirection, NodeShape } from "@/types/flow";
 import { MarkerType } from "@xyflow/react";
 import {
   DEFAULT_NODE_WIDTH,
   DEFAULT_NODE_HEIGHT,
   DEFAULT_DIAMOND_SIZE,
 } from "@/lib/constants";
+import { idToCounter } from "@/lib/id";
 import { autoLayout } from "./autoLayout";
+import type { MermaidLayoutResult } from "./renderLayout";
 
 /**
  * Reverse of escapeMermaid: convert Mermaid escape sequences back to original characters.
  */
 export function unescapeMermaid(text: string): string {
-  return text
+  let result = text
     .replace(/#amp;/g, "&")
     .replace(/#quot;/g, '"')
     .replace(/#lt;/g, "<")
@@ -23,6 +25,13 @@ export function unescapeMermaid(text: string): string {
     .replace(/#rpar;/g, ")")
     .replace(/#lbrack;/g, "[")
     .replace(/#rbrack;/g, "]");
+  // Strip surrounding double quotes (Mermaid quoted labels), but only if length > 2
+  if (result.length > 2 && result.startsWith('"') && result.endsWith('"')) {
+    result = result.slice(1, -1);
+  }
+  // Convert <br/> and <br> to newline
+  result = result.replace(/<br\s*\/?>/gi, "\n");
+  return result;
 }
 
 // Shape patterns ordered from most specific (longest delimiters) to least specific
@@ -84,7 +93,8 @@ function getNodeSize(shape: NodeShape): { width: number; height: number } {
 }
 
 // Split an edge line by arrow patterns, returning segments and labels
-const ARROW_RE = /\s*-->\s*(?:\|([^|]*)\|)?\s*/;
+// Supports: -->, -.->, ===>, ~~>, -->, etc.
+const ARROW_RE = /\s*(?:-+\.?-*>|={2,}>|~{2,}>)\s*(?:\|([^|]*)\|)?\s*/;
 
 function splitEdgeLine(line: string): { segments: string[]; labels: string[] } | null {
   const segments: string[] = [];
@@ -106,19 +116,40 @@ function splitEdgeLine(line: string): { segments: string[]; labels: string[] } |
   return { segments, labels };
 }
 
-export function parseMermaid(text: string, edgeType?: import("@/types/flow").EdgeType): {
+/**
+ * Sort nodes so that parent nodes come before their children.
+ * React Flow requires this ordering for parentId relationships to work correctly.
+ */
+function sortNodesParentFirst(nodes: FlowNode[]): void {
+  nodes.sort((a, b) => {
+    // Nodes without parentId come first
+    if (!a.parentId && b.parentId) return -1;
+    if (a.parentId && !b.parentId) return 1;
+    // If b is a child of a, a comes first
+    if (b.parentId === a.id) return -1;
+    if (a.parentId === b.id) return 1;
+    return 0;
+  });
+}
+
+// Subgraph padding constants for bounding box calculation
+const SUBGRAPH_PADDING_X = 40;
+const SUBGRAPH_PADDING_Y_TOP = 40;
+const SUBGRAPH_PADDING_Y_BOTTOM = 20;
+
+export function parseMermaid(text: string, edgeType?: import("@/types/flow").EdgeType, layout?: MermaidLayoutResult): {
   nodes: FlowNode[];
   edges: FlowEdge[];
   direction: FlowDirection;
   nextIdCounter: number;
-  componentDefinitions?: ComponentDefinition[];
+  componentDefinitions: import("@/types/flow").ComponentDefinition[];
 } {
   const lines = text.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
   if (lines.length === 0) throw new Error("Empty input");
 
   // Parse direction from first line
-  const headerMatch = lines[0].match(/^graph\s+(TD|LR|TB|BT)$/i);
-  if (!headerMatch) throw new Error("Invalid header: expected 'graph TD|LR|TB|BT'");
+  const headerMatch = lines[0].match(/^(?:graph|flowchart)\s+(TD|LR|TB|BT)$/i);
+  if (!headerMatch) throw new Error("Invalid header: expected 'graph TD|LR' or 'flowchart TD|LR'");
 
   let direction: FlowDirection = "TD";
   const dirStr = headerMatch[1].toUpperCase();
@@ -154,12 +185,12 @@ export function parseMermaid(text: string, edgeType?: import("@/types/flow").Edg
     return id;
   }
 
-  // Track subgraph contexts for component definition creation
+  // Track subgraph contexts for subgraphGroup creation
   const subgraphStack: { id: string; label: string }[] = [];
-  const subgraphNodes = new Map<string, ComponentInternalNode[]>();
-  const subgraphEdges = new Map<string, ComponentInternalEdge[]>();
   const subgraphLabels = new Map<string, string>();
   const nodeToSubgraph = new Map<string, string>();
+  // Track parent subgraph for nested subgraphs
+  const subgraphParentMap = new Map<string, string>();
 
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i];
@@ -168,11 +199,14 @@ export function parseMermaid(text: string, edgeType?: import("@/types/flow").Edg
     const subgraphMatch = line.match(/^subgraph\s+(\S+?)(?:\[([^\]]*)\])?\s*$/);
     if (subgraphMatch) {
       const sgId = subgraphMatch[1];
-      const sgLabel = subgraphMatch[2] ? unescapeMermaid(subgraphMatch[2]) : sgId;
+      const rawLabel = subgraphMatch[2] ?? sgId;
+      const sgLabel = unescapeMermaid(rawLabel);
+      // Track parent subgraph for nesting
+      if (subgraphStack.length > 0) {
+        subgraphParentMap.set(sgId, subgraphStack[subgraphStack.length - 1].id);
+      }
       subgraphStack.push({ id: sgId, label: sgLabel });
       subgraphLabels.set(sgId, sgLabel);
-      subgraphNodes.set(sgId, []);
-      subgraphEdges.set(sgId, []);
       continue;
     }
 
@@ -197,25 +231,11 @@ export function parseMermaid(text: string, edgeType?: import("@/types/flow").Edg
       }
 
       for (let j = 0; j < resolvedIds.length - 1; j++) {
-        const edgeEntry = {
+        edgeList.push({
           source: resolvedIds[j],
           target: resolvedIds[j + 1],
           label: labels[j] ?? "",
-        };
-        edgeList.push(edgeEntry);
-
-        // If both in same subgraph, also add to subgraph edges
-        if (currentSubgraph) {
-          const sgEdges = subgraphEdges.get(currentSubgraph);
-          if (sgEdges) {
-            sgEdges.push({
-              id: `e${sgEdges.length}`,
-              source: resolvedIds[j],
-              target: resolvedIds[j + 1],
-              label: labels[j] || undefined,
-            });
-          }
-        }
+        });
       }
       continue;
     }
@@ -230,27 +250,48 @@ export function parseMermaid(text: string, edgeType?: import("@/types/flow").Edg
     }
   }
 
-  // Build subgraph internal node lists
-  for (const [nodeId, sgId] of nodeToSubgraph) {
-    const sgNodes = subgraphNodes.get(sgId);
-    const def = nodeDefs.get(nodeId);
-    if (sgNodes && def) {
-      sgNodes.push({
-        id: nodeId,
-        label: def.label,
-        shape: def.shape,
-        position: { x: 50, y: sgNodes.length * 80 },
-      });
-    }
+  // Remove nodeDefs entries that conflict with subgraph IDs
+  // (When a subgraph ID is used as an edge endpoint, ensureNode creates a regular node entry,
+  //  but the subgraph should be represented as a subgraphGroup node instead)
+  for (const sgId of subgraphLabels.keys()) {
+    nodeDefs.delete(sgId);
   }
 
-  // Auto-layout
-  const nodeIds = [...nodeDefs.keys()].map((id) => ({ id }));
+  // Layout: use mermaid.js layout if provided, otherwise fall back to autoLayout
+  let positions: Map<string, { x: number; y: number }>;
+  let backEdges: Set<string> = new Set<string>();
   const sizeMap = new Map<string, { width: number; height: number }>();
-  for (const [id, def] of nodeDefs) {
-    sizeMap.set(id, getNodeSize(def.shape));
+
+  if (layout) {
+    // Use mermaid.js layout result
+    positions = new Map<string, { x: number; y: number }>();
+    backEdges = new Set<string>();
+
+    for (const [id, def] of nodeDefs) {
+      const mNode = layout.nodes.get(id);
+      if (mNode) {
+        // mermaid.js returns center coordinates; convert to top-left
+        positions.set(id, {
+          x: mNode.x - mNode.width / 2,
+          y: mNode.y - mNode.height / 2,
+        });
+        sizeMap.set(id, { width: mNode.width, height: mNode.height });
+      } else {
+        const size = getNodeSize(def.shape);
+        positions.set(id, { x: 0, y: 0 });
+        sizeMap.set(id, size);
+      }
+    }
+  } else {
+    // Fall back to autoLayout
+    const nodeIds = [...nodeDefs.keys()].map((id) => ({ id }));
+    for (const [id, def] of nodeDefs) {
+      sizeMap.set(id, getNodeSize(def.shape));
+    }
+    const layoutResult = autoLayout(nodeIds, edgeList, direction, sizeMap);
+    positions = layoutResult.positions;
+    backEdges = layoutResult.backEdges;
   }
-  const { positions, backEdges } = autoLayout(nodeIds, edgeList, direction, sizeMap);
 
   // Build FlowNode[]
   const nodes: FlowNode[] = [];
@@ -258,15 +299,11 @@ export function parseMermaid(text: string, edgeType?: import("@/types/flow").Edg
 
   for (const [id, def] of nodeDefs) {
     const pos = positions.get(id) ?? { x: 0, y: 0 };
-    const size = getNodeSize(def.shape);
+    const size = sizeMap.get(id) ?? getNodeSize(def.shape);
 
     // Track highest alphabetic ID counter
     if (/^[A-Z]+$/.test(id)) {
-      let counter = 0;
-      for (let c = 0; c < id.length; c++) {
-        counter = counter * 26 + (id.charCodeAt(c) - 64);
-      }
-      counter -= 1;
+      const counter = idToCounter(id);
       if (counter + 1 > maxCounter) maxCounter = counter + 1;
     }
 
@@ -308,79 +345,171 @@ export function parseMermaid(text: string, edgeType?: import("@/types/flow").Edg
     });
   }
 
-  // Build component definitions and replace subgraph nodes with instances
-  const componentDefs: ComponentDefinition[] = [];
-  for (const [sgId, sgLabel] of subgraphLabels) {
-    const sgNodes = subgraphNodes.get(sgId) ?? [];
-    const sgEdges = subgraphEdges.get(sgId) ?? [];
-    if (sgNodes.length === 0) continue;
+  // Convert subgraphs to subgraphGroup nodes with child parentId relationships
+  // Two-pass approach:
+  //   Pass 1 (innermost first): Create subgraphGroup nodes with absolute positions, record sizes
+  //   Pass 2 (outermost first): Convert positions to relative coordinates
 
-    const defId = `comp_parse_${sgId}`;
-    componentDefs.push({
-      id: defId,
-      name: sgLabel,
-      version: 1,
-      nodes: sgNodes,
-      edges: sgEdges,
-      entryNodeId: sgNodes[0]?.id ?? null,
-      exitNodeId: sgNodes[sgNodes.length - 1]?.id ?? null,
-    });
+  // Store absolute positions and sizes of each subgraph
+  const sgAbsPositions = new Map<string, { x: number; y: number }>();
+  const sgSizes = new Map<string, { width: number; height: number }>();
 
-    // Remove subgraph children from top-level nodes
-    const childIds = new Set(sgNodes.map((n) => n.id));
-    const remaining = nodes.filter((n) => !childIds.has(n.id));
+  // Build processing order: innermost first (post-order DFS)
+  // Post-order ensures children are pushed before parents → innermost first without reversing
+  const sgProcessOrder: string[] = [];
+  const sgProcessed = new Set<string>();
+  const enqueueSg = (sgId: string) => {
+    if (sgProcessed.has(sgId)) return;
+    sgProcessed.add(sgId);
+    // Recurse into children first
+    for (const [nestedSgId, parentSgId] of subgraphParentMap) {
+      if (parentSgId === sgId) enqueueSg(nestedSgId);
+    }
+    // Push self after children (post-order: innermost first)
+    sgProcessOrder.push(sgId);
+  };
+  // Start from root subgraphs (those without parents)
+  for (const sgId of subgraphLabels.keys()) {
+    if (!subgraphParentMap.has(sgId)) enqueueSg(sgId);
+  }
+  // Also process any orphan subgraphs
+  for (const sgId of subgraphLabels.keys()) enqueueSg(sgId);
 
-    // Compute center position of removed nodes
-    const childPositions = nodes.filter((n) => childIds.has(n.id));
-    const avgX = childPositions.length > 0
-      ? childPositions.reduce((sum, n) => sum + n.position.x, 0) / childPositions.length
-      : 250;
-    const avgY = childPositions.length > 0
-      ? childPositions.reduce((sum, n) => sum + n.position.y, 0) / childPositions.length
-      : 150;
+  // Pass 1: Create subgraphGroup nodes with absolute positions (innermost first)
+  for (const sgId of sgProcessOrder) {
+    const sgLabel = subgraphLabels.get(sgId)!;
 
-    // Create instance node
-    const instanceId = sgId;
-    remaining.push({
-      id: instanceId,
-      type: "componentInstance",
-      position: { x: avgX - 100, y: avgY - 50 },
-      data: {
-        label: sgLabel,
-        shape: "rectangle" as NodeShape,
-        componentDefinitionId: defId,
-        componentInstanceName: sgLabel,
-        componentSyncVersion: 1,
-        collapsed: false,
-      },
-      style: { width: Math.max(200, sgNodes.length * 80), height: Math.max(100, sgNodes.length * 60) },
-    });
+    // Collect direct child node IDs for this subgraph
+    const childNodeIds = new Set<string>();
+    for (const [nodeId, parentSgId] of nodeToSubgraph) {
+      if (parentSgId === sgId) childNodeIds.add(nodeId);
+    }
 
-    // Update edges: remap child node references to instance node
-    nodes.length = 0;
-    nodes.push(...remaining);
+    // Get direct child nodes (regular nodes only)
+    const childNodes = nodes.filter((n) => childNodeIds.has(n.id));
 
-    // Remap edges from child nodes to instance
-    for (let ei = edges.length - 1; ei >= 0; ei--) {
-      const e = edges[ei];
-      const srcInChild = childIds.has(e.source);
-      const tgtInChild = childIds.has(e.target);
-      if (srcInChild && tgtInChild) {
-        // Internal edge - remove from top-level
-        edges.splice(ei, 1);
-      } else if (srcInChild) {
-        edges[ei] = { ...e, source: instanceId, id: `${instanceId}-${e.target}-${e.sourceHandle ?? "d"}-${e.targetHandle ?? "d"}` };
-      } else if (tgtInChild) {
-        edges[ei] = { ...e, target: instanceId, id: `${e.source}-${instanceId}-${e.sourceHandle ?? "d"}-${e.targetHandle ?? "d"}` };
+    // Also include nested subgraph group nodes whose parent is this subgraph
+    const nestedSgIds: string[] = [];
+    for (const [nestedSgId, parentSgId] of subgraphParentMap) {
+      if (parentSgId === sgId) nestedSgIds.push(nestedSgId);
+    }
+
+    // Compute absolute position and size of this subgraph
+    let sgAbsPos: { x: number; y: number };
+    let sgSize: { width: number; height: number };
+
+    const sgLayout = layout?.subgraphs.get(sgId);
+    if (sgLayout) {
+      sgAbsPos = { x: sgLayout.x, y: sgLayout.y };
+      sgSize = { width: sgLayout.width, height: sgLayout.height };
+    } else {
+      // Compute bounding box from child positions (all absolute at this point)
+      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+      // Include regular child nodes
+      for (const child of childNodes) {
+        const w = (child.style as Record<string, number>)?.width ?? DEFAULT_NODE_WIDTH;
+        const h = (child.style as Record<string, number>)?.height ?? DEFAULT_NODE_HEIGHT;
+        if (child.position.x < minX) minX = child.position.x;
+        if (child.position.y < minY) minY = child.position.y;
+        if (child.position.x + w > maxX) maxX = child.position.x + w;
+        if (child.position.y + h > maxY) maxY = child.position.y + h;
+      }
+      // Include nested subgraph groups (already created in nodes by innermost-first order)
+      for (const nestedSgId of nestedSgIds) {
+        const nestedAbsPos = sgAbsPositions.get(nestedSgId);
+        const nestedSize = sgSizes.get(nestedSgId);
+        if (nestedAbsPos && nestedSize) {
+          if (nestedAbsPos.x < minX) minX = nestedAbsPos.x;
+          if (nestedAbsPos.y < minY) minY = nestedAbsPos.y;
+          if (nestedAbsPos.x + nestedSize.width > maxX) maxX = nestedAbsPos.x + nestedSize.width;
+          if (nestedAbsPos.y + nestedSize.height > maxY) maxY = nestedAbsPos.y + nestedSize.height;
+        }
+      }
+
+      if (minX === Infinity) {
+        sgAbsPos = { x: 0, y: 0 };
+        sgSize = { width: 200, height: 100 };
+      } else {
+        sgAbsPos = {
+          x: minX - SUBGRAPH_PADDING_X,
+          y: minY - SUBGRAPH_PADDING_Y_TOP,
+        };
+        sgSize = {
+          width: (maxX - minX) + SUBGRAPH_PADDING_X * 2,
+          height: (maxY - minY) + SUBGRAPH_PADDING_Y_TOP + SUBGRAPH_PADDING_Y_BOTTOM,
+        };
+      }
+    }
+
+    sgAbsPositions.set(sgId, sgAbsPos);
+    sgSizes.set(sgId, sgSize);
+
+    // Create subgraphGroup node with absolute position (will be converted to relative in Pass 2)
+    const parentSgId = subgraphParentMap.get(sgId);
+    const sgNode: FlowNode = {
+      id: sgId,
+      type: "subgraphGroup",
+      position: { ...sgAbsPos }, // absolute; converted to relative in Pass 2
+      data: { label: sgLabel, shape: "rectangle" as NodeShape, isSubgraphGroup: true },
+      style: { width: sgSize.width, height: sgSize.height },
+      zIndex: -1,
+    };
+
+    if (parentSgId) {
+      sgNode.parentId = parentSgId;
+      sgNode.data.subgraphParentId = parentSgId;
+    }
+
+    nodes.push(sgNode);
+
+    // Set parentId and subgraphParentId on child nodes (positions stay absolute for now)
+    for (const child of childNodes) {
+      child.parentId = sgId;
+      child.data = { ...child.data, subgraphParentId: sgId };
+    }
+  }
+
+  // Pass 2: Convert all positions from absolute to relative (outermost first)
+  // Process outermost first so that when we convert a child's position,
+  // we subtract the parent's absolute position (not yet modified)
+  const sgOutermostFirst = [...sgProcessOrder].reverse();
+  for (const sgId of sgOutermostFirst) {
+    const sgAbsPos = sgAbsPositions.get(sgId)!;
+
+    // Convert this subgraphGroup node's position to relative (if nested)
+    const parentSgId = subgraphParentMap.get(sgId);
+    if (parentSgId) {
+      const parentAbsPos = sgAbsPositions.get(parentSgId)!;
+      const sgNode = nodes.find((n) => n.id === sgId);
+      if (sgNode) {
+        sgNode.position = {
+          x: sgAbsPos.x - parentAbsPos.x,
+          y: sgAbsPos.y - parentAbsPos.y,
+        };
+      }
+    }
+
+    // Convert direct child nodes' positions to relative to this subgraph
+    for (const [nodeId, parentSg] of nodeToSubgraph) {
+      if (parentSg !== sgId) continue;
+      const child = nodes.find((n) => n.id === nodeId);
+      if (child) {
+        child.position = {
+          x: child.position.x - sgAbsPos.x,
+          y: child.position.y - sgAbsPos.y,
+        };
       }
     }
   }
+
+  // Sort nodes so parents come before children (React Flow requires this for parentId)
+  sortNodesParentFirst(nodes);
 
   return {
     nodes,
     edges,
     direction,
     nextIdCounter: maxCounter,
-    componentDefinitions: componentDefs.length > 0 ? componentDefs : undefined,
+    componentDefinitions: [],
   };
 }

--- a/src/lib/mermaid/renderLayout.ts
+++ b/src/lib/mermaid/renderLayout.ts
@@ -1,0 +1,149 @@
+/**
+ * Render Mermaid text using mermaid.js and extract node/subgraph positions and sizes from the SVG output.
+ */
+
+export interface MermaidNodeLayout {
+  id: string;
+  x: number;       // center X
+  y: number;       // center Y
+  width: number;
+  height: number;
+}
+
+export interface MermaidSubgraphLayout {
+  id: string;
+  x: number;       // top-left X
+  y: number;       // top-left Y
+  width: number;
+  height: number;
+}
+
+export interface MermaidLayoutResult {
+  nodes: Map<string, MermaidNodeLayout>;
+  subgraphs: Map<string, MermaidSubgraphLayout>;
+}
+
+let renderCounter = 0;
+
+/**
+ * Strip mermaid's ID decorations to recover the original node/subgraph ID.
+ * mermaid.js generates IDs like "flowchart-A-0" for node "A".
+ */
+function extractId(rawId: string): string {
+  // Pattern: "flowchart-{id}-{number}" or just the id with prefix
+  const match = rawId.match(/^flowchart-(.+?)-\d+$/);
+  if (match) return match[1];
+  // Fallback: return as-is
+  return rawId;
+}
+
+/**
+ * Get the absolute SVG coordinates of an element by walking the transform chain.
+ * Accumulates all translate transforms from the element up to the SVG root.
+ */
+function getAbsoluteTranslate(el: SVGElement, svgRoot: SVGSVGElement): { x: number; y: number } {
+  let x = 0;
+  let y = 0;
+  let current: SVGElement | null = el;
+
+  while (current && current !== svgRoot) {
+    const transform = current.getAttribute("transform");
+    if (transform) {
+      const translateMatch = transform.match(/translate\(\s*([\d.-]+)\s*[,\s]\s*([\d.-]+)\s*\)/);
+      if (translateMatch) {
+        x += parseFloat(translateMatch[1]);
+        y += parseFloat(translateMatch[2]);
+      }
+    }
+    current = current.parentElement as SVGElement | null;
+  }
+
+  return { x, y };
+}
+
+export async function renderMermaidLayout(
+  mermaidText: string,
+): Promise<MermaidLayoutResult> {
+  const mermaid = (await import("mermaid")).default;
+  mermaid.initialize({
+    startOnLoad: false,
+    securityLevel: "loose",
+    flowchart: {
+      htmlLabels: false,  // SVG labels for accurate size measurement
+    },
+  });
+
+  // Unique ID per render call to avoid mermaid.js internal cache conflicts
+  const containerId = `mermaid-layout-tmp-${++renderCounter}`;
+
+  // Create off-screen container
+  const container = document.createElement("div");
+  container.style.position = "absolute";
+  container.style.left = "-9999px";
+  container.style.top = "-9999px";
+  document.body.appendChild(container);
+
+  try {
+    const { svg } = await mermaid.render(containerId, mermaidText);
+    container.innerHTML = svg;
+    const svgEl = container.querySelector("svg");
+    if (!svgEl) throw new Error("Failed to render Mermaid SVG");
+
+    const nodes = new Map<string, MermaidNodeLayout>();
+    const subgraphs = new Map<string, MermaidSubgraphLayout>();
+
+    // Extract node positions and sizes from .node elements
+    // Walk the full transform chain to get absolute SVG coordinates
+    svgEl.querySelectorAll(".node").forEach((el) => {
+      const gEl = el as SVGGraphicsElement;
+      const rawId = gEl.id;
+      if (!rawId) return;
+      const id = extractId(rawId);
+
+      const bbox = gEl.getBBox();
+      const abs = getAbsoluteTranslate(gEl as SVGElement, svgEl);
+
+      nodes.set(id, {
+        id,
+        x: abs.x,
+        y: abs.y,
+        width: bbox.width,
+        height: bbox.height,
+      });
+    });
+
+    // Extract subgraph (cluster) positions and sizes
+    svgEl.querySelectorAll(".cluster").forEach((el) => {
+      const gEl = el as SVGGraphicsElement;
+      const rawId = gEl.id;
+      if (!rawId) return;
+      const id = extractId(rawId);
+
+      const rect = gEl.querySelector("rect");
+      if (!rect) return;
+
+      const rectX = parseFloat(rect.getAttribute("x") ?? "0");
+      const rectY = parseFloat(rect.getAttribute("y") ?? "0");
+      const width = parseFloat(rect.getAttribute("width") ?? "0");
+      const height = parseFloat(rect.getAttribute("height") ?? "0");
+
+      // Walk transform chain for absolute position
+      const abs = getAbsoluteTranslate(gEl as SVGElement, svgEl);
+
+      subgraphs.set(id, {
+        id,
+        x: rectX + abs.x,
+        y: rectY + abs.y,
+        width,
+        height,
+      });
+    });
+
+    return { nodes, subgraphs };
+  } finally {
+    document.body.removeChild(container);
+    // Clean up mermaid internal cache element if it exists
+    const cached = document.getElementById(containerId);
+    if (cached) cached.remove();
+  }
+}

--- a/src/store/__tests__/mermaid-update.test.ts
+++ b/src/store/__tests__/mermaid-update.test.ts
@@ -9,7 +9,7 @@ describe("Mermaid output after node deletion (#21)", () => {
 
   it("generateMermaid returns only header when nodes/edges are empty", () => {
     const result = generateMermaid([], [], "TD");
-    expect(result).toBe("graph TD");
+    expect(result).toBe("flowchart TD");
   });
 
   it("store nodes/edges are empty after removeNodes", () => {
@@ -135,6 +135,6 @@ describe("Mermaid output after node deletion (#21)", () => {
 
     const { nodes, edges } = useFlowStore.getState();
     const mermaid = generateMermaid(nodes, edges, "TD");
-    expect(mermaid).toBe("graph TD");
+    expect(mermaid).toBe("flowchart TD");
   });
 });

--- a/src/store/useFlowStore.ts
+++ b/src/store/useFlowStore.ts
@@ -146,6 +146,17 @@ export const useFlowStore = create<FlowState>()(
             idSet.add(n.id);
           }
         }
+        // Also remove children of subgraphGroup nodes being deleted (with nesting support)
+        let changed = true;
+        while (changed) {
+          changed = false;
+          for (const n of nodes) {
+            if (!idSet.has(n.id) && n.data.subgraphParentId && idSet.has(n.data.subgraphParentId as string)) {
+              idSet.add(n.id);
+              changed = true;
+            }
+          }
+        }
         set({
           nodes: nodes.filter((n) => !idSet.has(n.id)),
           edges: edges.filter(
@@ -1245,6 +1256,14 @@ export const useFlowStore = create<FlowState>()(
           const def = defs.find((d) => d.id === n.data.componentDefinitionId);
           if (!def?.direction) return n;
           return { ...n, data: { ...n.data, componentDefinitionDirection: def.direction } };
+        });
+        // Sort nodes so parents come before children (React Flow requires this for parentId)
+        nodes.sort((a, b) => {
+          if (!a.parentId && b.parentId) return -1;
+          if (a.parentId && !b.parentId) return 1;
+          if (b.parentId === a.id) return -1;
+          if (a.parentId === b.id) return 1;
+          return 0;
         });
         set({
           nodes,

--- a/src/types/flow.ts
+++ b/src/types/flow.ts
@@ -136,6 +136,9 @@ export interface FlowNodeData extends Record<string, unknown> {
   // Component child node (internal node belonging to an instance)
   componentParentId?: string;
   componentInternalId?: string;
+  // Subgraph (visual group) fields
+  isSubgraphGroup?: boolean;
+  subgraphParentId?: string;
 }
 
 export interface Waypoint {


### PR DESCRIPTION
## Summary

- **mermaid.jsレンダリング**: ノードサイズ・配置をMermaid Live Editorと同等に（#26, #27）
- **subgraphGroup**: Mermaidの`subgraph`をReact Flow `parentId`親子関係で表現（ComponentDefinition変換を廃止）
- **パーサー拡張**: `-.->` 矢印、`"..."` クォート除去、`<br/>`→改行変換、`flowchart` 構文対応

## 変更内容

### 新規ファイル
- `SubgraphGroupNode.tsx` — subgraphグループ枠コンポーネント（ラベル、リサイズ、接続ハンドル）
- `renderLayout.ts` — mermaid.jsでSVGレンダリング→座標・サイズ抽出
- `specs/subgraph.md` — subgraph仕様書

### 主要変更
- `parse.ts` — subgraph→subgraphGroupノード生成、mermaid.jsレイアウト対応、パーサー拡張
- `generate.ts` — 再帰的`emitSubgraphBlock()`でsubgraph出力、`flowchart`構文に統一
- `serialize.ts` / `deserialize.ts` / `schema.ts` — `isSubgraphGroup`, `subgraphParentId` 永続化
- `MermaidImportDialog.tsx` — async化、mermaid.jsレイアウト→autoLayoutフォールバック
- `useFlowStore.ts` — removeNodes連動削除、loadStateノード順序ソート

## Test plan

- [x] 全148テスト合格
- [x] subgraph付きMermaidテキストのインポート確認（3階層ネスト）
- [x] .flowmaid export → import ラウンドトリップ
- [x] subgraphGroup削除時の子ノード連動削除
- [x] subgraphなしMermaidの回帰テスト
- [x] キャンバス上のエッジ表示（SubgraphGroupNodeのハンドル追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)